### PR TITLE
Feature/use new calendar request modal

### DIFF
--- a/App/src/components/NewCalendar.js
+++ b/App/src/components/NewCalendar.js
@@ -4,7 +4,6 @@ import { jsx } from "@emotion/core";
 import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
 import { WorkshiftDot } from "./WorkshiftDot";
 import format from "date-fns/format";
-import isEqual from "date-fns/is_equal";
 
 function TH({ styles, ...props }) {
   return (

--- a/App/src/components/NewCalendar.js
+++ b/App/src/components/NewCalendar.js
@@ -4,6 +4,7 @@ import { jsx } from "@emotion/core";
 import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
 import { WorkshiftDot } from "./WorkshiftDot";
 import format from "date-fns/format";
+import isEqual from "date-fns/is_equal";
 
 function TH({ styles, ...props }) {
   return (
@@ -97,7 +98,9 @@ function NewCalendar({
   startDate = new Date(),
   workshiftList,
   forecast,
-  users
+  users,
+  selectedUsers = [],
+  selectedDate = null
 }) {
   const dates = Array.from({ length: 7 }, (_, index) => {
     const date = new Date(startDate);
@@ -221,6 +224,7 @@ function NewCalendar({
                   workShift =>
                     workShift.date === format(startDate, "YYYY/MM/DD")
                 );
+
                 const user = users.find(
                   user => user.id === parseInt(userId, 10)
                 );
@@ -237,7 +241,17 @@ function NewCalendar({
                       {user && user.name}
                     </TD>
                     {workshifts.map((workShift, index) => (
-                      <TD key={workShift.date}>
+                      <TD
+                        key={workShift.date}
+                        styles={{
+                          backgroundColor:
+                            isSelectedUser &&
+                            format(new Date(workShift.date), "YYYY-MM-DD") ===
+                              format(new Date(selectedDate), "YYYY-MM-DD")
+                              ? "#35469C"
+                              : "white"
+                        }}
+                      >
                         {onShiftClick ? (
                           <button
                             css={{

--- a/App/src/components/NewCalendar.js
+++ b/App/src/components/NewCalendar.js
@@ -224,6 +224,9 @@ function NewCalendar({
                 const user = users.find(
                   user => user.id === parseInt(userId, 10)
                 );
+                if (!user) return null;
+
+                const isSelectedUser = selectedUsers.includes(user.id);
                 const workshifts = workShiftsPerUser.slice(
                   startIndex,
                   startIndex + 7

--- a/App/src/components/NewCalendar.js
+++ b/App/src/components/NewCalendar.js
@@ -86,20 +86,17 @@ function formatDateTitle(startDate, endDate) {
   return `${format(startDate, "MMM YYYY")} - ${format(endDate, "MMM YYYY")}`;
 }
 
-/**
- * This component receive the props listed below
- */
 function NewCalendar({
-  onPrev,
-  onNext,
-  onToday,
-  onShiftClick,
-  startDate = new Date(),
-  workshiftList,
-  forecast,
-  users,
-  selectedUsers = [],
-  selectedDate = null
+  onPrev, // function to know when the user wants to go to the next week, button not rendered if not passed
+  onNext, // function to know when the user wants to go to the next week, button not rendered if not passed
+  onToday, // function to know when the user clicks on the button to go to the current date, button not rendered if not passed
+  onShiftClick, // function to know when the user clicks on a shift, shifts not clickables if not passed
+  startDate = new Date(), // the start date of the week, by default current date
+  workshiftList, // the list of workshifts per user
+  forecast, // the forecast data
+  users, // the list of users to show
+  selectedUsers = [], // the list of users to highlight
+  selectedDate = null // the date to highlight those users
 }) {
   const dates = Array.from({ length: 7 }, (_, index) => {
     const date = new Date(startDate);

--- a/App/src/components/RequestModal.js
+++ b/App/src/components/RequestModal.js
@@ -3,9 +3,16 @@ import Modal from "react-modal";
 import { updateRequest, cancelRequest } from "../services/request";
 import schedules from "../services/schedule";
 import { users } from "../services/user";
-import PreviewWeek from "./PreviewWeek";
-import RequestForm from "../components/RequestForm";
-import RequestFormAdmin from "../components/RequestFormAdmin";
+import RequestForm from "./RequestForm";
+import RequestFormAdmin from "./RequestFormAdmin";
+import NewCalendar from "./NewCalendar";
+
+function getInitialStartDate(now) {
+  const day = now.getDay();
+  if (day === 0) return now;
+  now.setDate(now.getDate() - day);
+  return now;
+}
 
 function RequestModal({
   requests,
@@ -17,12 +24,8 @@ function RequestModal({
 }) {
   const [events, setEvents] = useState([]);
   const [frontdesks, setFrontdesks] = useState([]);
-  const [request, setRequest] = useState({});
-
-  React.useEffect(() => {
-    const reqFind = requests.find(req => req.id === id);
-    setRequest(reqFind);
-  }, [requests, id]);
+  const request = requests.find(req => req.id === id);
+  const startDate = getInitialStartDate(new Date(request.date_Shift));
 
   useEffect(() => {
     async function fetchData() {
@@ -40,7 +43,7 @@ function RequestModal({
     fetchData();
   }, []);
 
-  if (events.length === 0) return null;
+  // if (events.length === 0) return null;
   if (frontdesks.length === 0) return null;
 
   function onClick(event) {
@@ -82,6 +85,15 @@ function RequestModal({
     }
   };
 
+  const workShiftConcat = events.reduce((groups, event) => {
+    return {
+      ...groups,
+      [event.user_id]: groups[event.user_id]
+        ? groups[event.user_id].concat(event.workShifts)
+        : event.workShifts
+    };
+  }, {});
+
   return (
     <Modal
       isOpen={isOpen}
@@ -100,8 +112,17 @@ function RequestModal({
           )
         )}
       </div>
-      <PreviewWeek request={request} frontdesks={frontdesks} events={events} />
-      
+
+      <NewCalendar
+        users={frontdesks.filter(
+          ({ id }) => id === request.requester_id || id === request.requested_id
+        )}
+        workshiftList={workShiftConcat}
+        startDate={startDate}
+        selectedUsers={[request.requester_id, request.requested_id]}
+        selectedDate={request.date_Shift}
+      />
+
       {isAdmin ? (
         <RequestFormAdmin onClick={onClick} />
       ) : (

--- a/App/src/components/RequestModal.js
+++ b/App/src/components/RequestModal.js
@@ -6,13 +6,7 @@ import { users } from "../services/user";
 import RequestForm from "./RequestForm";
 import RequestFormAdmin from "./RequestFormAdmin";
 import NewCalendar from "./NewCalendar";
-
-function getInitialStartDate(now) {
-  const day = now.getDay();
-  if (day === 0) return now;
-  now.setDate(now.getDate() - day);
-  return now;
-}
+import getInitialWeekDate from "../utils/get-initial-week-date";
 
 function RequestModal({
   requests,
@@ -25,7 +19,7 @@ function RequestModal({
   const [events, setEvents] = useState([]);
   const [frontdesks, setFrontdesks] = useState([]);
   const request = requests.find(req => req.id === id);
-  const startDate = getInitialStartDate(new Date(request.date_Shift));
+  const startDate = getInitialWeekDate(new Date(request.date_Shift));
 
   useEffect(() => {
     async function fetchData() {

--- a/App/src/utils/get-initial-week-date.js
+++ b/App/src/utils/get-initial-week-date.js
@@ -1,0 +1,8 @@
+function getInitialWeekDate(now = new Date()) {
+  const day = now.getDay();
+  if (day === 0) return now;
+  now.setDate(now.getDate() - day);
+  return now;
+}
+
+export default getInitialWeekDate

--- a/App/src/views/HomeView.js
+++ b/App/src/views/HomeView.js
@@ -13,18 +13,12 @@ import { Button } from "../components/Ui";
 import { WorkshiftDot } from "../components/WorkshiftDot";
 import NewCalendar from "../components/NewCalendar";
 
-function getInitialStartDate() {
-  const now = new Date();
-  const day = now.getDay();
-  if (day === 0) return now;
-  now.setDate(now.getDate() - day);
-  return now;
-}
+import getInitialWeekDate from "../utils/get-initial-week-date";
 
 function HomeView() {
   const [modalIsOpen, setModalOpen] = useState(false);
   const user = useUser();
-  const [startDate, setStartDate] = useState(getInitialStartDate());
+  const [startDate, setStartDate] = useState(getInitialWeekDate());
   const [start, setStart] = useState(0);
   const [end, setEnd] = useState(7);
   const [events, setEvents] = useState([]);
@@ -73,7 +67,7 @@ function HomeView() {
   }
 
   function handleTodayClick() {
-    setStartDate(getInitialStartDate());
+    setStartDate(getInitialWeekDate());
   }
 
   function handleChangeSchedule(event) {

--- a/App/src/views/RequestsView.js
+++ b/App/src/views/RequestsView.js
@@ -99,7 +99,7 @@ function RequestsView() {
           />
         ))}
       </ul>
-      {requests && (
+      {requests && !!modalIsOpen && (
         <RequestModal
           isOpen={!!modalIsOpen}
           onRequestClose={() => setModalOpen(false)}

--- a/App/src/views/RequestsView.js
+++ b/App/src/views/RequestsView.js
@@ -105,7 +105,7 @@ function RequestsView() {
           onRequestClose={() => setModalOpen(false)}
           id={id}
           setRequests={setRequests}
-          requests={requests}
+          requests={[...requests, ...requestsAdmin]}
           isAdmin={user.rol === "Supervisor"}
         />
       )}


### PR DESCRIPTION
This PR uses the NewCalendar component inside the request modal, both admin and users.

It also adds support to highlight one or more users in a certain date, useful for highlighting the changed dates (this is what this PR uses it for) and for highlighting the picked dates by the users when creating a request change.

I also created a little utility function to calculate the initial date of the week based on another date, defaults to current date, used to know the startDate of the new calendar.